### PR TITLE
fix: ensure newline after vim.cmd[[source...]] in neovim init.lua

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -472,7 +472,7 @@ in
                   luaRcContent =
                     lib.optionalString (
                       wrappedNeovim'.initRc != ""
-                    ) "vim.cmd [[source ${pkgs.writeText "nvim-init-home-manager.vim" wrappedNeovim'.initRc}]]"
+                    ) "vim.cmd [[source ${pkgs.writeText "nvim-init-home-manager.vim" wrappedNeovim'.initRc}]]\n"
                     + config.programs.neovim.extraLuaConfig
                     + lib.optionalString hasLuaConfig config.programs.neovim.generatedConfigs.lua;
                 in


### PR DESCRIPTION
### Description

Fix an issue where the generated `~/.config/nvim/init.lua` lacks a newline after the `vim.cmd [[source ...]]` directive. Without this newline, subsequent lua configuration is concatenated onto the same line, breaking lua syntax.

`init.lua` Before:

```
vim.cmd [[source /nix/store/...]]vim.opt.rtp:prepend(...)
```

After:

```
vim.cmd [[source /nix/store/...]]
vim.opt.rtp:prepend(...)
```

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

#### Maintainer CC

@khaneliman